### PR TITLE
sys.setdefaultencoding() was removed in Python 3

### DIFF
--- a/nq_browser.py
+++ b/nq_browser.py
@@ -45,8 +45,11 @@ import numpy as np
 import tornado.web
 import tornado.wsgi
 
-reload(sys)
-sys.setdefaultencoding('utf-8')
+try:
+  reload(sys)  # Python 2
+  sys.setdefaultencoding('utf-8')
+except NameError:
+  pass         # Python 3
 
 FLAGS = flags.FLAGS
 


### PR DESCRIPTION
__reload()__ was moved and __sys.setdefaultencoding()__ was removed in Python 3 because it already has a default encoding of utf-8.